### PR TITLE
Prevent NUI Callback Spam

### DIFF
--- a/src/components/MailList.tsx
+++ b/src/components/MailList.tsx
@@ -20,7 +20,7 @@ const MailList = () => {
     getMailItems()
       .then(val => setMails(val))
       .catch(console.error);
-  });
+  }, []);
 
   useNuiEvent<Mail[]>('npwd_qbx_mail', 'newMail', (data) => {
     if (!data) return;


### PR DESCRIPTION
## Description

This change prevents the useEffect from repeatably calling the NUI callback infinitely.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
